### PR TITLE
Add missing dependency: BurntSushi/toml

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,29 @@
 generator: gg 1.0.0-pre
 imports:
+- name: github.com/BurntSushi/toml
+  root: github.com/BurntSushi/toml
+  repo: https://github.com/BurntSushi/toml.git
+  version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
+  revision: 0.3.1
+  ref: tags/v0.3.1
+  time: 2018-08-15T03:47:33-07:00
+  noRequirements: true
+  commands:
+  - github.com/BurntSushi/toml/_examples
+  - github.com/BurntSushi/toml/cmd/toml-test-decoder
+  - github.com/BurntSushi/toml/cmd/toml-test-encoder
+  - github.com/BurntSushi/toml/cmd/tomlv
+  exports:
+  - github.com/BurntSushi/toml
+  imports:
+    github.com/BurntSushi/toml/_examples:
+    - github.com/BurntSushi/toml
+    github.com/BurntSushi/toml/cmd/toml-test-decoder:
+    - github.com/BurntSushi/toml
+    github.com/BurntSushi/toml/cmd/toml-test-encoder:
+    - github.com/BurntSushi/toml
+    github.com/BurntSushi/toml/cmd/tomlv:
+    - github.com/BurntSushi/toml
 - name: github.com/Masterminds/semver
   root: github.com/Masterminds/semver
   repo: https://github.com/Masterminds/semver.git

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,30 +1,23 @@
-package: github.com/uber/gg
+package: github.com/kriskowal/gg
 import:
+- package: github.com/BurntSushi/toml
+  version: ~0.3.1
 - package: github.com/Masterminds/semver
   version: ^1.4.2
-  repo: https://github.com/Masterminds/semver.git
 - package: github.com/RyanCarrier/dijkstra
   version: master
-  repo: https://github.com/RyanCarrier/dijkstra.git
 - package: github.com/chzyer/readline
   version: ^1.4.0
-  repo: https://github.com/chzyer/readline.git
 - package: github.com/google/shlex
   version: master
-  repo: https://github.com/google/shlex.git
 - package: go.uber.org/multierr
   version: ^1.1.0
-  repo: https://github.com/uber-go/multierr
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.2.2
-  repo: https://github.com/stretchr/testify.git
 - package: gopkg.in/src-d/go-billy.v4
   version: ^4.3.0
-  repo: https://gopkg.in/src-d/go-billy.v4
 - package: gopkg.in/src-d/go-git.v4
   version: ^4.7.0
-  repo: https://gopkg.in/src-d/go-git.v4
 - package: gopkg.in/yaml.v2
   version: ^2.2.1
-  repo: https://gopkg.in/yaml.v2


### PR DESCRIPTION
BurntSushi/toml was missing from glide.yaml/lock. Added by running,

    gg r a github.com/BurntSushi/toml wgy w